### PR TITLE
iOS-#90 [Measuring Tool] Implement toast message when there is no edi…

### DIFF
--- a/Amoogye.xcodeproj/project.pbxproj
+++ b/Amoogye.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		A3E7E2E623203D8000DE7A40 /* RealmMeterial.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E7E2E523203D8000DE7A40 /* RealmMeterial.swift */; };
 		A3E7E2EA23203E5C00DE7A40 /* RealmMeterialManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E7E2E923203E5C00DE7A40 /* RealmMeterialManager.swift */; };
 		A3E7E2EC23203EE200DE7A40 /* MeterialManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E7E2EB23203EE200DE7A40 /* MeterialManager.swift */; };
+		A3F1DDCC2323A1DD00C35760 /* MeasuringToolViewController + Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F1DDCB2323A1DD00C35760 /* MeasuringToolViewController + Toast.swift */; };
 		BC10E39C39F4E1B94E1C1748 /* Pods_Amoogye.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E4964B64B9F236BE83C290B /* Pods_Amoogye.framework */; };
 /* End PBXBuildFile section */
 
@@ -151,6 +152,7 @@
 		A3E7E2E523203D8000DE7A40 /* RealmMeterial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMeterial.swift; sourceTree = "<group>"; };
 		A3E7E2E923203E5C00DE7A40 /* RealmMeterialManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMeterialManager.swift; sourceTree = "<group>"; };
 		A3E7E2EB23203EE200DE7A40 /* MeterialManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeterialManager.swift; sourceTree = "<group>"; };
+		A3F1DDCB2323A1DD00C35760 /* MeasuringToolViewController + Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeasuringToolViewController + Toast.swift"; sourceTree = "<group>"; };
 		FF1B1192416A93293D91C594 /* Pods-Amoogye.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amoogye.debug.xcconfig"; path = "Target Support Files/Pods-Amoogye/Pods-Amoogye.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -346,6 +348,7 @@
 				A3E7E2F1232061E200DE7A40 /* MeasuringToolViewController + ToolTabBar.swift */,
 				A3E7E2F5232062DA00DE7A40 /* MeasuringToolViewController + EditButton.swift */,
 				A3E7E2F32320622000DE7A40 /* MeasuringToolViewController + DimScreen.swift */,
+				A3F1DDCB2323A1DD00C35760 /* MeasuringToolViewController + Toast.swift */,
 				3A8550E322F00AF30003C584 /* SetNameForNewToolViewController.swift */,
 				3A8550E022F00AF30003C584 /* MeasureNewToolViewController.swift */,
 				3A8550E222F00AF30003C584 /* CompleteNewToolViewController.swift */,
@@ -652,6 +655,7 @@
 				A3E7E2F42320622000DE7A40 /* MeasuringToolViewController + DimScreen.swift in Sources */,
 				A3B6897522FC87CB002FB31D /* SwinjectStoryboard+Setup.swift in Sources */,
 				A3B689C72300705C002FB31D /* UIColor+.swift in Sources */,
+				A3F1DDCC2323A1DD00C35760 /* MeasuringToolViewController + Toast.swift in Sources */,
 				A3B689DC2304301E002FB31D /* NumericKeyboardView.swift in Sources */,
 				3A8550E822F00AF30003C584 /* SetNameForNewToolViewController.swift in Sources */,
 				3AE9AAB322F98A4900F09850 /* CustomTextfieldManager.swift in Sources */,

--- a/Amoogye/MeasuringTool/MeasuringToolViewController + EditButton.swift
+++ b/Amoogye/MeasuringTool/MeasuringToolViewController + EditButton.swift
@@ -10,6 +10,11 @@ import UIKit
 
 extension MeasuringToolViewController {
     @IBAction func clickEditMeasuringToolButton(_ sender: UIButton) {
+        if self.checkIsToast() {
+            self.showToast(message: "삭제할 수 있는 계량도구가 없습니다")
+            return
+        }
+
         hideTabBar()
         self.editMeasuringToolButton.isHidden = true
         showEditButtons()

--- a/Amoogye/MeasuringTool/MeasuringToolViewController + Toast.swift
+++ b/Amoogye/MeasuringTool/MeasuringToolViewController + Toast.swift
@@ -1,0 +1,51 @@
+//
+//  MeasuringToolViewController + Toast.swift
+//  Amoogye
+//
+//  Created by JunHui Kim on 07/09/2019.
+//  Copyright © 2019 KookKook. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+extension MeasuringToolViewController {
+    func showToast(message: String) {
+        let toastLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        setupToast(toastLabel: toastLabel, message: message)
+        self.view.addSubview(toastLabel)
+
+        toastLabel.snp.makeConstraints { (make) -> Void in
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-12)
+            make.centerX.equalTo(self.view)
+            make.width.equalTo(208)
+            make.height.equalTo(36)
+        }
+
+        UIView.animate(
+            withDuration: 1.0, delay: 0.5, animations: {
+                toastLabel.alpha = 0.0
+        }, completion: { (_) in
+                toastLabel.removeFromSuperview()
+        })
+    }
+
+    private func setupToast(toastLabel: UILabel, message: String) {
+        toastLabel.backgroundColor = UIColor(displayP3Red: 77.0/255.0, green: 86.0/255.0, blue: 107.0/255.0, alpha: 0.9)
+        toastLabel.font = UIFont.systemFont(ofSize: 12)
+        toastLabel.textColor = UIColor.white
+        toastLabel.textAlignment = .center
+        toastLabel.text = message
+        toastLabel.layer.cornerRadius = 6
+        toastLabel.clipsToBounds = true
+    }
+
+    func checkIsToast() -> Bool {
+        for tool in self.measuringToolList ?? [] {
+            if tool.isEditable == true {
+                return false
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
…table item

## Related Issue

resolve: #90

## Description

- 편집할 수 있는 계량 도구 없을 경우, 편집 버튼 눌렀을 때 토스트 창 띄우기 구현

![image](https://user-images.githubusercontent.com/34789831/64472401-c7460600-d198-11e9-8c40-aba3c5963601.png)